### PR TITLE
Allow numerics in names + fix the removal log message

### DIFF
--- a/commands/claim.js
+++ b/commands/claim.js
@@ -5,7 +5,7 @@ var formatter = require('../lib/formatter');
 
 module.exports = function(app) {
 
-  app.command('^claim (resource )?([a-zA-Z\-]+)( .+)?', function(bot, message) {
+  app.command('^claim (resource )?([a-zA-Z0-9\-]+)( .+)?', function(bot, message) {
     var resourceName = message.match[2];
     var resource;
     var length = message.match[3];

--- a/commands/release.js
+++ b/commands/release.js
@@ -1,7 +1,7 @@
 var async = require('async');
 
 module.exports = function(app) {
-  app.command('^(release|unclaim) (claim (on )?)?([a-zA-Z\-]+)', function(bot, message) {
+  app.command('^(release|unclaim) (claim (on )?)?([a-zA-Z0-9\-]+)', function(bot, message) {
     var resourceName = message.match[4];
     var now = new Date();
 

--- a/commands/remove.js
+++ b/commands/remove.js
@@ -25,7 +25,7 @@ module.exports = function(app) {
     };
 
     var respondWithSuccessMessage = function(resource, cb) {
-      bot.reply(message, 'Great, I\'ve added a resource named `' + resourceName + '`', cb);
+      bot.reply(message, 'Okay, I\'ve removed the resource named `' + resourceName + '`', cb);
     };
 
     var onError = function(err) {


### PR DESCRIPTION
One thing I think would be nice to have, one thing that was clearly unintended.

1) Changes the allowed characters inside resource names from `[a-zA-Z\-]+)( .+)?` to `[a-zA-Z0-9\-]+)( .+)?`; I often find names like `build-machine-3` or `testbed-1`.
2) Fixes the log message for resource removal, which was a duplicate of resource addition.

Thanks for the bot, we're really enjoying it!